### PR TITLE
Fix Content-Type header

### DIFF
--- a/jsonpify.rb
+++ b/jsonpify.rb
@@ -1,6 +1,6 @@
 get '/' do
   if params['resource']
-    content_type :json
+    content_type :js
     httparty_error = {"error" => "HTTParty Error!"}.to_json
     return {"error" => "You must specify a callback parameter for JSONP"}.to_json unless params['callback']
     resource = params.delete('resource')


### PR DESCRIPTION
Hi Max,

I think `Content-Type` header should be `application/javascript` instead of
`application/json` for JSONP responses.

It also causes Safari to raise a warning:

```
Resource interpreted as Script but transferred with MIME type application/json.
```

See discussion:
http://stackoverflow.com/questions/111302/best-content-type-to-serve-jsonp
